### PR TITLE
[cleanup] Format-string marker spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Any non-empty configuration variables included in the config file found in each 
         "feature",
         "tag 2"
       ],
-      "format_string": " - <<tags>> <<message>> — <<commit_type_hyperlink>> — <<contributor_handle>>",
+      "format_string": " - << tags >> << message >> — << commit_type_hyperlink >> — << contributor_handle >>",
       "capitalizes_message": true,
       "excluded": true
     }

--- a/Resources/config.json.template
+++ b/Resources/config.json.template
@@ -12,7 +12,7 @@
     {
       "title": "Features",
       "tags": ["*"],
-      "format_string": " - <<tags>> <<message>> — <<commit_type_hyperlink>> — <<contributor_handle>>"
+      "format_string": " - << tags >> << message >> — << commit_type_hyperlink >> — << contributor_handle >>"
     },
     {
       "title": "Bug Fixes",

--- a/Sources/FinchCore/Section/Line/FormatTemplate.swift
+++ b/Sources/FinchCore/Section/Line/FormatTemplate.swift
@@ -19,7 +19,7 @@ extension FormatTemplate {
         self.init(outputtables: outputtables)
     }
 
-    // Equivalent to formatString: " - << tags >> << message >> — << commit_type_hyperlink >> — << contributor_handle >>"
+    // Equivalent to: " - << tags >> << message >> — << commit_type_hyperlink >> — << contributor_handle >>"
     static let `default`: FormatTemplate = .init(
         outputtables: [
             " - ",

--- a/Sources/FinchCore/Section/Line/FormatTemplate.swift
+++ b/Sources/FinchCore/Section/Line/FormatTemplate.swift
@@ -19,7 +19,7 @@ extension FormatTemplate {
         self.init(outputtables: outputtables)
     }
 
-    // Equivalent to formatString: " - <<tags>> <<message>> — <<commit_type_hyperlink>> — <<contributor_handle>>"
+    // Equivalent to formatString: " - << tags >> << message >> — << commit_type_hyperlink >> — << contributor_handle >>"
     static let `default`: FormatTemplate = .init(
         outputtables: [
             " - ",
@@ -86,17 +86,17 @@ private extension String {
             let outputtable: LineOutputtable
 
             switch component {
-            case "<<\(string(for: .commitTypeHyperlink))>>":
+            case "<< \(string(for: .commitTypeHyperlink)) >>":
                 outputtable = format(component: .commitTypeHyperlink)
-            case "<<\(string(for: .contributorEmail))>>":
+            case "<< \(string(for: .contributorEmail)) >>":
                 outputtable = format(component: .contributorEmail)
-            case "<<\(string(for: .contributorHandle))>>":
+            case "<< \(string(for: .contributorHandle)) >>":
                 outputtable = format(component: .contributorHandle)
-            case "<<\(string(for: .message))>>":
+            case "<< \(string(for: .message)) >>":
                 outputtable = format(component: .message)
-            case "<<\(string(for: .tags))>>":
+            case "<< \(string(for: .tags)) >>":
                 outputtable = format(component: .tags)
-            case "<<\(string(for: .sha))>>":
+            case "<< \(string(for: .sha)) >>":
                 outputtable = format(component: .sha)
             default:
                 outputtable = component

--- a/Tests/FinchAppTests/Resources/default_config.json
+++ b/Tests/FinchAppTests/Resources/default_config.json
@@ -37,7 +37,7 @@
                                "upgrade",
                                "cleanup"
                                ],
-                      "format_string": " - <<message>> — <<commit_type_hyperlink>>"
+                      "format_string": " - << message >> — << commit_type_hyperlink >>"
                       }
                       ],
     "footer": "\n### Timeline\n- Begin development:\n- Feature cut-off / Start of bake / dogfooding:\n- Submission:\n- Release (expected):\n- Release (actual):\n",

--- a/Tests/FinchAppTests/Resources/excluded_section_config.json
+++ b/Tests/FinchAppTests/Resources/excluded_section_config.json
@@ -21,7 +21,7 @@
                 "upgrade",
                 "cleanup"
             ],
-            "format_string": " - <<message>> — <<commit_type_hyperlink>>"
+            "format_string": " - << message >> — << commit_type_hyperlink >>"
         }
     ]
 }


### PR DESCRIPTION
Add spacing on either side of format-string/format-component markers for better config readability