### PR TITLE
[platform][ci] Linting fix and parent job optimization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,10 @@ jobs:
 workflows:
   build:
     jobs:
-      - swiftlint
+      - swiftlint:
+          filters:
+            tags:
+              only: /.*/
       - build_app:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,11 @@ commands:
 
 jobs:
 
-  build_app:
+  resolve:
     executor: mac
     steps:
       - checkout
-      - run:
-          command: make build
-          name: Build app
+      - run: swift package resolve
       - persist:
           path: .build
 
@@ -162,7 +160,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build_app:
+      - resolve:
           filters:
             tags:
               only: /.*/
@@ -171,10 +169,10 @@ workflows:
             tags:
               only: /.*/
           requires:
-            - build_app
+            - resolve
       - build_package:
           requires:
-            - build_app
+            - resolve
           filters:
             branches:
               ignore: /.*/
@@ -182,7 +180,7 @@ workflows:
               only: /.*/
       - generate_changelog:
           requires:
-            - build_app
+            - resolve
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
- Ensure linting performed on tagged builds
- Use `swift package resolve` instead of `make build` as parent job