### PR TITLE
[improvements] show-example promoted to subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ View Finch's configurable components in this [configuration template](Resources/
 Finch searches for a hidden `.finch` directory containing a `config.yml` file. The `.finch` directory can be placed in either the home, current, or project directories. Alternatively, if you provide a custom path through an env variable, Finch will look for a valid configuration file at the included path. Finch also allows for private config files in case you prefer to keep portions of your config outside your version-control sytem. See the [search behavior](#config-merging-and-search-behavior) below.
 
 ### Config format
-`config.yml` should be a valid YAML file in the same format as this [config template](Resources/template.config.yml). (Note: Not all keys need to be included as Finch uses default values where needed. You can see an example config at any time by running `finch config --show-example`.
+`config.yml` should be a valid YAML file in the same format as this [config template](Resources/template.config.yml). (Note: Not all keys need to be included as Finch uses default values where needed. You can see an example config at any time by running `finch config show-example`.
 
 ### Config merging and search behavior
 Finch will start with a default configuration and will search several paths for valid configuration files to override existing values. Any non-empty elements included in later configuration files will override their existing counterparts. Empty or omitted config file components will be ignored.

--- a/Sources/FinchApp/Command-Routing/Commands/Config/ConfigCommand.swift
+++ b/Sources/FinchApp/Command-Routing/Commands/Config/ConfigCommand.swift
@@ -18,6 +18,10 @@ final class ConfigCommand: Command {
         fileprivate(set) var shouldPrintExample: Bool
     }
 
+    private enum Mode: String {
+        case showExample = "show-example"
+    }
+
     private typealias Binder = ArgumentBinder<Options>
 
     /// ConfigCommand's name.
@@ -28,13 +32,15 @@ final class ConfigCommand: Command {
     private let subparser: ArgumentParser
 
     /// :nodoc:
-    init(
-        meta: App.Meta,
-        parser: ArgumentParser
-        ) {
+    init(meta: App.Meta, parser: ArgumentParser) {
         self.subparser = parser.add(
             subparser: name,
             overview: Strings.Config.commandOverview(appName: meta.name)
+        )
+
+        subparser.add(
+            subparser: Mode.showExample.rawValue,
+            overview: Strings.Config.Options.showExample
         )
 
         bindOptions(to: binder, meta: meta)
@@ -54,11 +60,7 @@ final class ConfigCommand: Command {
     }
 
     private func bindOptions(to binder: Binder, meta: App.Meta) {
-        binder.bind(option: subparser.add(
-            option: "--show-example",
-            kind: Bool.self,
-            usage: Strings.Config.Options.showExample
-        )) { $0.shouldPrintExample = $1 }
+        binder.bind(parser: subparser) { $0.shouldPrintExample = $1 == Mode.showExample.rawValue }
     }
 }
 

--- a/Tests/FinchAppTests/AppRunnerTests.swift
+++ b/Tests/FinchAppTests/AppRunnerTests.swift
@@ -29,7 +29,7 @@ final class AppRunnerTests: XCTestCase {
             environment: [:],
             meta: .mock,
             output: outputMock
-        ).run(arguments: ["finch", "config", "--show-example"])
+        ).run(arguments: ["finch", "config", "show-example"])
 
         assertSnapshot(matching: outputMock.outputs, as: .dump)
     }


### PR DESCRIPTION
Changes `show-example` from an option to a subcommand