### PR TITLE
[feature][improvement] Add --config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In many cases it may be easiest to create a new shell function when your shell s
 
 ```
 project-changelog() {
-  finch compare $@ --project-dir="$HOME/Code/YourProject" --release-manager=$(git config --get user.email)
+  finch compare --project-dir="$HOME/Code/YourProject" --release-manager=$(git config --get user.email) $@
 }
 
 # Used in the following manner:

--- a/Sources/FinchApp/App.swift
+++ b/Sources/FinchApp/App.swift
@@ -37,7 +37,10 @@ public struct App {
 
     /// App options received from the commandline.
     struct Options {
-        ///The project directory if it is not the current working directory.
+        /// Path to config
+        var configPath: String?
+
+        /// The project directory if it is not the current working directory.
         var projectDir: String?
 
         /// Print the app version information and exit.
@@ -76,6 +79,7 @@ public struct App {
 /// :nodoc:
 extension App.Options {
     static let blank: App.Options = .init(
+        configPath: nil,
         projectDir: nil,
         shouldPrintVersion: false,
         verbose: false

--- a/Sources/FinchApp/Command-Routing/CommandRegistry.swift
+++ b/Sources/FinchApp/Command-Routing/CommandRegistry.swift
@@ -73,5 +73,11 @@ final class CommandRegistry {
             kind: Bool.self,
             usage: Strings.App.Options.showVersion(appName: meta.name)
         )) { $0.shouldPrintVersion = $1 }
+
+        binder.bind(option: parser.add(
+            option: "--config",
+            kind: String.self,
+            usage: Strings.App.Options.configPath
+        )) { $0.configPath = $1 }
     }
 }

--- a/Sources/FinchApp/Command-Routing/Commands/Compare/CompareCommand.swift
+++ b/Sources/FinchApp/Command-Routing/Commands/Compare/CompareCommand.swift
@@ -102,11 +102,18 @@ final class CompareCommand: Command {
      * to the global app options.
      *
      * #### Options for global binding
-     * - `--verbose`
+     * - `--config`
      * - `--project-dir`
+     * - `--verbose`
      */
     @discardableResult
     func bindingGlobalOptions(to binder: CommandRegistry.Binder) -> CompareCommand {
+        binder.bind(option: subparser.add(
+            option: "--config",
+            kind: String.self,
+            usage: Strings.App.Options.configPath
+        )) { $0.configPath = $1 }
+
         binder.bind(option: subparser.add(
             option: "--verbose",
             shortName: "-v",

--- a/Sources/FinchApp/Models/Configurator.swift
+++ b/Sources/FinchApp/Models/Configurator.swift
@@ -60,6 +60,7 @@ struct Configurator {
         self.immediateResolver = .init(fileManager: fileManager)
 
         let immediateReturnPaths = [
+            options.configPath,
             environment["\(meta.name.uppercased())_CONFIG"]
         ]
 

--- a/Sources/FinchApp/Strings.swift
+++ b/Sources/FinchApp/Strings.swift
@@ -19,13 +19,15 @@ enum Strings {
         }
 
         enum Options {
+            static var configPath: String = "Path to config"
+
             static var projectDir: String = "Path to project if command is run from separate directory"
 
             static func showVersion(appName: String) -> String {
                 return "Displays current \(appName) version and build number"
             }
 
-            static var verbose: String = "Run command with verbose output"
+            static var verbose: String = "Run with verbose output"
         }
     }
 

--- a/Tests/FinchAppTests/ConfiguratorTests.swift
+++ b/Tests/FinchAppTests/ConfiguratorTests.swift
@@ -26,6 +26,7 @@ final class ConfiguratorTests: TestCase {
         assertSnapshot(
             matching: Configurator(
                 options: .init(
+                    configPath: nil,
                     projectDir: "current",
                     shouldPrintVersion: false,
                     verbose: false

--- a/Tests/FinchAppTests/Mocks/Mocks.swift
+++ b/Tests/FinchAppTests/Mocks/Mocks.swift
@@ -62,6 +62,7 @@ extension App.Meta {
 
 extension App.Options {
     static let mock: App.Options = .init(
+        configPath: nil,
         projectDir: "home/dir",
         shouldPrintVersion: false,
         verbose: false

--- a/Tests/FinchAppTests/__Snapshots__/CommandRegistryTests/testParsingCompare.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/CommandRegistryTests/testParsingCompare.1.txt
@@ -2,6 +2,7 @@
   ▿ .0: Optional<String>
     - some: "compare"
   ▿ .1: Options
+    - configPath: Optional<String>.none
     - projectDir: Optional<String>.none
     - shouldPrintVersion: false
     - verbose: false

--- a/Tests/FinchAppTests/__Snapshots__/CommandRegistryTests/testParsingCompareManyOptions.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/CommandRegistryTests/testParsingCompareManyOptions.1.txt
@@ -2,6 +2,7 @@
   ▿ .0: Optional<String>
     - some: "compare"
   ▿ .1: Options
+    - configPath: Optional<String>.none
     - projectDir: Optional<String>.none
     - shouldPrintVersion: false
     - verbose: true

--- a/Tests/FinchAppTests/__Snapshots__/CommandRegistryTests/testParsingVersion.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/CommandRegistryTests/testParsingVersion.1.txt
@@ -1,6 +1,7 @@
 ▿ (2 elements)
   - .0: Optional<String>.none
   ▿ .1: Options
+    - configPath: Optional<String>.none
     - projectDir: Optional<String>.none
     - shouldPrintVersion: true
     - verbose: false


### PR DESCRIPTION
Adds `--config` option to pass in direct path to config in addition to env var option. `--config` supersedes env var