### PR TITLE
[bug-fix] Fix default sectionInfos overriding child config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
 
   linux:
     docker:
-      - image: norionomura/swift:latest
+      - image: norionomura/swift:423
 
 commands:
 

--- a/Sources/FinchCore/Configuration/FormatConfiguration.swift
+++ b/Sources/FinchCore/Configuration/FormatConfiguration.swift
@@ -93,7 +93,7 @@ extension FormatConfiguration: SubConfiguration {
 /// :nodoc:
 extension FormatConfiguration: Mergeable {
     public func merge(into other: inout FormatConfiguration) {
-        if !sectionInfos.isEmpty {
+        if !sectionInfos.isEmpty, sectionInfos.allSatisfy({ !$0.isDefault }) {
             other.sectionInfos = sectionInfos
         }
 

--- a/Sources/FinchCore/Configuration/FormatConfiguration.swift
+++ b/Sources/FinchCore/Configuration/FormatConfiguration.swift
@@ -93,7 +93,7 @@ extension FormatConfiguration: SubConfiguration {
 /// :nodoc:
 extension FormatConfiguration: Mergeable {
     public func merge(into other: inout FormatConfiguration) {
-        if !sectionInfos.isEmpty, sectionInfos != .default {
+        if !sectionInfos.isEmpty {
             other.sectionInfos = sectionInfos
         }
 

--- a/Sources/FinchCore/Configuration/FormatConfiguration.swift
+++ b/Sources/FinchCore/Configuration/FormatConfiguration.swift
@@ -93,7 +93,7 @@ extension FormatConfiguration: SubConfiguration {
 /// :nodoc:
 extension FormatConfiguration: Mergeable {
     public func merge(into other: inout FormatConfiguration) {
-        if !sectionInfos.isEmpty {
+        if !sectionInfos.isEmpty, sectionInfos != .default {
             other.sectionInfos = sectionInfos
         }
 

--- a/Sources/FinchCore/Section/Line/FormatTemplate.swift
+++ b/Sources/FinchCore/Section/Line/FormatTemplate.swift
@@ -12,7 +12,23 @@
  * a `format_string` at the global or section level in the
  * configuration file.
  */
-public struct FormatTemplate {
+public struct FormatTemplate: Equatable {
+    public static func == (lhs: FormatTemplate, rhs: FormatTemplate) -> Bool {
+        guard lhs.outputtables.count == rhs.outputtables.count else {
+            return false
+        }
+        return zip(lhs.outputtables, rhs.outputtables).allSatisfy {
+            switch ($0, $1) {
+            case let (l, r) as (String, String):
+                return l == r
+            case let (l, r) as (FormatComponent, FormatComponent):
+                return l == r
+            default:
+                return false
+            }
+        }
+    }
+
     /// :nodoc:
     let outputtables: [LineOutputtable]
 }

--- a/Sources/FinchCore/Section/Line/FormatTemplate.swift
+++ b/Sources/FinchCore/Section/Line/FormatTemplate.swift
@@ -12,23 +12,7 @@
  * a `format_string` at the global or section level in the
  * configuration file.
  */
-public struct FormatTemplate: Equatable {
-    public static func == (lhs: FormatTemplate, rhs: FormatTemplate) -> Bool {
-        guard lhs.outputtables.count == rhs.outputtables.count else {
-            return false
-        }
-        return zip(lhs.outputtables, rhs.outputtables).allSatisfy {
-            switch ($0, $1) {
-            case let (l, r) as (String, String):
-                return l == r
-            case let (l, r) as (FormatComponent, FormatComponent):
-                return l == r
-            default:
-                return false
-            }
-        }
-    }
-
+public struct FormatTemplate {
     /// :nodoc:
     let outputtables: [LineOutputtable]
 }

--- a/Sources/FinchCore/Section/SectionInfo.swift
+++ b/Sources/FinchCore/Section/SectionInfo.swift
@@ -61,6 +61,12 @@ public struct SectionInfo {
      * The section's unique title.
      */
     public let title: String
+
+    /**
+    * Internal flag to indicate this should be ignored when
+    * overwriting downstream configs
+    */
+    let isDefault: Bool
 }
 
 /// :nodoc:
@@ -82,6 +88,7 @@ extension SectionInfo: Codable {
         self.formatTemplate = FormatTemplate(formatString: formatString)
         self.tags = try container.decode(forKey: .tags)
         self.title = try container.decode(forKey: .title)
+        self.isDefault = false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -101,7 +108,8 @@ extension SectionInfo {
         excluded: false,
         formatTemplate: .default,
         tags: ["*"],
-        title: "Features"
+        title: "Features",
+        isDefault: true
     )
 
     fileprivate static let bugs: SectionInfo = .init(
@@ -109,7 +117,8 @@ extension SectionInfo {
         excluded: false,
         formatTemplate: .default,
         tags: ["bugfix", "bug fix", "bug"],
-        title: "Bug Fixes"
+        title: "Bug Fixes",
+        isDefault: true
     )
 }
 

--- a/Sources/FinchCore/Section/SectionInfo.swift
+++ b/Sources/FinchCore/Section/SectionInfo.swift
@@ -113,8 +113,6 @@ extension SectionInfo {
     )
 }
 
-extension SectionInfo: Equatable {}
-
 /// :nodoc:
 extension Array where Element == SectionInfo {
     static let `default`: [SectionInfo] = [

--- a/Sources/FinchCore/Section/SectionInfo.swift
+++ b/Sources/FinchCore/Section/SectionInfo.swift
@@ -113,6 +113,8 @@ extension SectionInfo {
     )
 }
 
+extension SectionInfo: Equatable {}
+
 /// :nodoc:
 extension Array where Element == SectionInfo {
     static let `default`: [SectionInfo] = [

--- a/Tests/FinchAppTests/ConfigurationTests.swift
+++ b/Tests/FinchAppTests/ConfigurationTests.swift
@@ -1,0 +1,14 @@
+@testable import FinchCore
+import SnapshotTesting
+import XCTest
+
+final class ConfigurationTests: XCTestCase {
+    func testOverriddenWithPartialConfig() {
+        var config: Configuration = .mockExcludedSection
+        let otherConfig: Configuration = .default(projectDir: "")
+
+        otherConfig.merge(into: &config)
+
+        assertSnapshot(matching: config, as: .dump)
+    }
+}

--- a/Tests/FinchAppTests/ConfigurationTests.swift
+++ b/Tests/FinchAppTests/ConfigurationTests.swift
@@ -2,7 +2,7 @@
 import SnapshotTesting
 import XCTest
 
-final class ConfigurationTests: XCTestCase {
+final class ConfigurationTests: TestCase {
     func testOverriddenWithPartialConfig() {
         var config: Configuration = .mockExcludedSection
         let otherConfig: Configuration = .default(projectDir: "")

--- a/Tests/FinchAppTests/__Snapshots__/ConfigurationTests/testOverriddenWithPartialConfig.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/ConfigurationTests/testOverriddenWithPartialConfig.1.txt
@@ -41,6 +41,7 @@
         - capitalizesMessage: false
         - excluded: true
         - formatTemplate: Optional<FormatTemplate>.none
+        - isDefault: false
         ▿ tags: 1 element
           - "*"
         - title: "Features"
@@ -48,6 +49,7 @@
         - capitalizesMessage: false
         - excluded: false
         - formatTemplate: Optional<FormatTemplate>.none
+        - isDefault: false
         ▿ tags: 3 elements
           - "bugfix"
           - "bug fix"
@@ -63,6 +65,7 @@
               - FormatComponent.message
               - " — "
               - FormatComponent.commitTypeHyperlink
+        - isDefault: false
         ▿ tags: 4 elements
           - "platform"
           - "tooling"

--- a/Tests/FinchAppTests/__Snapshots__/ConfigurationTests/testOverriddenWithPartialConfig.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/ConfigurationTests/testOverriddenWithPartialConfig.1.txt
@@ -1,0 +1,79 @@
+▿ Configuration
+  ▿ contributorsConfig: ContributorsConfiguration
+    - contributorHandlePrefix: "@"
+    ▿ contributors: 3 elements
+      ▿ Contributor
+        ▿ emails: 1 element
+          - "jony.ive@apple.com"
+        - handle: "Jony.Ive"
+      ▿ Contributor
+        ▿ emails: 1 element
+          - "long_live_the_citadel@rick.com"
+        - handle: "Rick.Sanchez"
+      ▿ Contributor
+        ▿ emails: 1 element
+          - "elvis1935+still-alive@theking.com"
+        - handle: "Elvis.Presley"
+  ▿ formatConfig: FormatConfiguration
+    ▿ delimiterConfig: DelimiterConfiguration
+      ▿ input: DelimiterPair
+        - left: "["
+        - right: "]"
+      ▿ output: DelimiterPair
+        - left: "|"
+        - right: "|"
+    ▿ footer: Optional<String>
+      - some: "\n### Timeline\n- Begin development:\n- Feature cut-off / Start of bake / dogfooding:\n- Submission:\n- Release (expected):\n- Release (actual):\n"
+    ▿ formatTemplate: Optional<FormatTemplate>
+      ▿ some: FormatTemplate
+        ▿ outputtables: 8 elements
+          - " - "
+          - FormatComponent.tags
+          - " "
+          - FormatComponent.message
+          - " - "
+          - FormatComponent.commitTypeHyperlink
+          - " - "
+          - FormatComponent.contributorHandle
+    - header: Optional<String>.none
+    ▿ sectionInfos: 3 elements
+      ▿ SectionInfo
+        - capitalizesMessage: false
+        - excluded: true
+        - formatTemplate: Optional<FormatTemplate>.none
+        ▿ tags: 1 element
+          - "*"
+        - title: "Features"
+      ▿ SectionInfo
+        - capitalizesMessage: false
+        - excluded: false
+        - formatTemplate: Optional<FormatTemplate>.none
+        ▿ tags: 3 elements
+          - "bugfix"
+          - "bug fix"
+          - "bug"
+        - title: "Bug Fixes"
+      ▿ SectionInfo
+        - capitalizesMessage: false
+        - excluded: false
+        ▿ formatTemplate: Optional<FormatTemplate>
+          ▿ some: FormatTemplate
+            ▿ outputtables: 4 elements
+              - " - "
+              - FormatComponent.message
+              - " — "
+              - FormatComponent.commitTypeHyperlink
+        ▿ tags: 4 elements
+          - "platform"
+          - "tooling"
+          - "upgrade"
+          - "cleanup"
+        - title: "Platform Improvements"
+  ▿ gitConfig: GitConfiguration
+    - branchPrefix: ""
+    - executablePath: Optional<String>.none
+    - repoBaseUrl: "https://github.com/citadel-of-ricks/C-137"
+  - projectDir: ""
+  ▿ resolutionCommandsConfig: ResolutionCommandsConfiguration
+    - buildNumber: Optional<String>.none
+    - versions: Optional<String>.none

--- a/Tests/FinchAppTests/__Snapshots__/ConfiguratorTests/testDefault.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/ConfiguratorTests/testDefault.1.txt
@@ -41,6 +41,7 @@
         - capitalizesMessage: false
         - excluded: false
         - formatTemplate: Optional<FormatTemplate>.none
+        - isDefault: false
         ▿ tags: 1 element
           - "*"
         - title: "Features"
@@ -48,6 +49,7 @@
         - capitalizesMessage: false
         - excluded: false
         - formatTemplate: Optional<FormatTemplate>.none
+        - isDefault: false
         ▿ tags: 3 elements
           - "bugfix"
           - "bug fix"
@@ -63,6 +65,7 @@
               - FormatComponent.message
               - " — "
               - FormatComponent.commitTypeHyperlink
+        - isDefault: false
         ▿ tags: 4 elements
           - "platform"
           - "tooling"

--- a/Tests/FinchAppTests/__Snapshots__/ConfiguratorTests/testProjectDirOption.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/ConfiguratorTests/testProjectDirOption.1.txt
@@ -41,6 +41,7 @@
         - capitalizesMessage: false
         - excluded: false
         - formatTemplate: Optional<FormatTemplate>.none
+        - isDefault: false
         ▿ tags: 1 element
           - "*"
         - title: "Features"
@@ -48,6 +49,7 @@
         - capitalizesMessage: false
         - excluded: false
         - formatTemplate: Optional<FormatTemplate>.none
+        - isDefault: false
         ▿ tags: 3 elements
           - "bugfix"
           - "bug fix"
@@ -63,6 +65,7 @@
               - FormatComponent.message
               - " — "
               - FormatComponent.commitTypeHyperlink
+        - isDefault: false
         ▿ tags: 4 elements
           - "platform"
           - "tooling"


### PR DESCRIPTION
Fixes #108 by adding an internal flag to `SectionInfo` indicating if the section info is a default created by Finch. If all infos in a child config were created by Finch, this now ignores the child/default section infos.