### PR TITLE
[bug fix] Empty branch merge in change-log

### DIFF
--- a/Sources/FinchApp/Command-Routing/Commands/Compare/ChangeLogModel.swift
+++ b/Sources/FinchApp/Command-Routing/Commands/Compare/ChangeLogModel.swift
@@ -67,6 +67,10 @@ final class ChangeLogModel: ChangeLogModelType {
             output.append(value)
         }
 
+        if options.useNewlineChar {
+            output = output.replacingOccurrences(of: "\n", with: "\\n")
+        }
+
         return output
     }
 

--- a/Sources/FinchApp/Command-Routing/Commands/Compare/CompareCommand.swift
+++ b/Sources/FinchApp/Command-Routing/Commands/Compare/CompareCommand.swift
@@ -50,6 +50,12 @@ final class CompareCommand: BaseCommand {
          * Note: Not used for section assignment.
          */
         fileprivate(set) var requiredTags: Set<String>
+
+        /**
+        * If the new line char is encoded as a new line or as the combined "\n"
+        * Note: Not used for section assignment.
+        */
+        fileprivate(set) var useNewlineChar: Bool
     }
 
     let versions: Key<Versions> = .init("--versions", description: Strings.Compare.Options.versions)
@@ -60,6 +66,7 @@ final class CompareCommand: BaseCommand {
     let noShowVersion: Flag = .init("--no-show-version", description: Strings.Compare.Options.noShowVersion)
     let releaseManager: Key<String> = .init("--release-manager", description: Strings.Compare.Options.releaseManager)
     let requiredTags: Key<[String]> = .init("--required-tags", description: Strings.Compare.Options.requiredTags)
+    let useNewlineChar: Flag = .init("--use-newline-char", description: Strings.Compare.Options.useNewlineChar)
 
     override var shortDescription: String { return Strings.Compare.commandOverview }
 
@@ -92,7 +99,8 @@ final class CompareCommand: BaseCommand {
             noFetch: noFetch.value,
             noShowVersion: noShowVersion.value,
             releaseManager: releaseManager.value,
-            requiredTags: Set(requiredTags.value ?? [])
+            requiredTags: Set(requiredTags.value ?? []),
+            useNewlineChar: useNewlineChar.value
         )
 
         let result = try model.changeLog(

--- a/Sources/FinchApp/Services/Git.swift
+++ b/Sources/FinchApp/Services/Git.swift
@@ -31,7 +31,6 @@ extension Git {
         return try git(
             "log",
             "--left-right",
-            "--graph",
             "--cherry-pick",
             "--oneline",
             "--format='format:&&&%H&&& - @@@%s@@@###%ae###'",

--- a/Sources/FinchApp/Strings.swift
+++ b/Sources/FinchApp/Strings.swift
@@ -54,6 +54,8 @@ enum Strings {
             static let requiredTags: String = "A set of tags required for commit presence in the final output. NOTE: Must be enclosed in quotes"
 
             static let versions: String = "'<version_1> <version_2>' Use explicit versions for the changelog instead of auto-resolving. NOTE: Must be enclosed in quotes"
+
+            static let useNewlineChar: String = "Encodes the line breaks as '\n' and not as the new-line value"
         }
 
         enum Error {

--- a/Tests/FinchAppTests/ChangeLogModelTests.swift
+++ b/Tests/FinchAppTests/ChangeLogModelTests.swift
@@ -116,7 +116,25 @@ final class ChangeLogModelTests: TestCase {
         )
     }
 
-    private func options(gitLog: String, requiredTags: [String] = [], showReleaseManager: Bool = true, showVersion: Bool = true) -> CompareCommand.Options {
+    func testUseNewlineChar() {
+        let output = try! model.changeLog(
+            options: options(
+                gitLog: multipleTagsMock,
+                requiredTags: ["app-store"],
+                showReleaseManager: false,
+                showVersion: false,
+                useNewlineChar: true
+            ),
+            app: .mock(configuration: .mockRequiredTags)
+        )
+
+        assertSnapshot(
+            matching: output,
+            as: .dump
+        )
+    }
+
+    private func options(gitLog: String, requiredTags: [String] = [], showReleaseManager: Bool = true, showVersion: Bool = true, useNewlineChar: Bool = false) -> CompareCommand.Options {
         let contributorEmail = Configuration.mock.contributorsConfig
             .contributors.first!.emails.first!
 
@@ -128,7 +146,8 @@ final class ChangeLogModelTests: TestCase {
             noFetch: true,
             noShowVersion: !showVersion,
             releaseManager: showReleaseManager ? contributorEmail : nil,
-            requiredTags: Set(requiredTags)
+            requiredTags: Set(requiredTags),
+            useNewlineChar: useNewlineChar
         )
     }
 }

--- a/Tests/FinchAppTests/__Snapshots__/ChangeLogModelTests/testUseNewlineChar.1.txt
+++ b/Tests/FinchAppTests/__Snapshots__/ChangeLogModelTests/testUseNewlineChar.1.txt
@@ -1,0 +1,1 @@
+- "\\n### Features\\n- Consolidate searchBar cornerRadius to 4, increase autocomplete-v3 term height\\n- Autocomplete V3\\n\\n### Bug Fixes\\n- Don\'t show express placement every cold start\\n- Minor bug fixes for cubs/pbi\\n\\n### Timeline\\n- Begin development:\\n- Feature cut-off / Start of bake / dogfooding:\\n- Submission:\\n- Release (expected):\\n- Release (actual):\\n"


### PR DESCRIPTION
A branch merger was recored to it's own commit, but with noe message, author or link. (This was a problem as github's API did not accept it when this was a tags change-log body.)

This sesames to be fixed by removing the --graph flag when fetching the git log.

E.g:
```
### Features
 - Merge pull request #11 from ...
 - |\ - [Commit](/commit/|\  ) - |\  
 - |/ - [Commit](/commit/|/  ) - |/  
 - Merge pull request #10 from ...
 - |\ - [Commit](/commit/|\  ) - |\  
 - Merge pull request #9 from ...
```